### PR TITLE
Disabled annoying added link when copying stuff

### DIFF
--- a/get-started.html
+++ b/get-started.html
@@ -442,6 +442,6 @@ drush kw-m development  # or `drush kw-manifests development`
     <script type="text/javascript">var _gaq = [['_setAccount', 'UA-36687951-1'], ['_trackPageview']];</script>
     <script type="text/javascript" src="http://www.google-analytics.com/ga.js"></script>
     <script type="text/javascript" src="http://w.sharethis.com/button/buttons.js"></script>
-    <script type="text/javascript">stLight.options({publisher: "23d62cc2-75a8-4f7a-8bc0-ef6411540241"});</script>
+    <script type="text/javascript">stLight.options({publisher: "23d62cc2-75a8-4f7a-8bc0-ef6411540241", doNotCopy: true});</script>
   </body>
 </html>


### PR DESCRIPTION
When you copy stuff from kraftwagen.org, it will add the link of the page and "See more at" to the text.
Very annoying when you copy commands.
